### PR TITLE
allow expected errors

### DIFF
--- a/tests/testthat/test_error_handling.R
+++ b/tests/testthat/test_error_handling.R
@@ -1,0 +1,20 @@
+library(delayed)
+library(testthat)
+library(future)
+context("Delayed Error Handling")
+
+delayed_error <- delayed_fun(stop)
+error_message <- "this is an error"
+
+
+test_that("compute returns first error it hits", { 
+  broken_delayed <- delayed_error(error_message)
+  expect_error(broken_delayed$compute(),error_message)
+})
+
+test_that("compute will return error instead of raising it if error is expected", { 
+  broken_delayed <- delayed_error(error_message)
+  broken_delayed$expect_error <- TRUE
+  result<- broken_delayed$compute()
+  expect_error(stop(result),error_message)
+})


### PR DESCRIPTION
Adds the `expect_error` flag `Delayed` objects to allow computation to continue if delayed objects return errors that can be handled by downstream delayed objects