### PR TITLE
fix runtime timing

### DIFF
--- a/R/Delayed.R
+++ b/R/Delayed.R
@@ -199,7 +199,7 @@ Delayed <- R6Class(
       if(is.null(private$.runtime_total)){
         sub_times <- sapply(self$delayed_dependencies,`[[`,"runtime")
         
-        private$.runtime_total <- sum(unlist(sub_times))+self$runtime_self
+        private$.runtime_total <- sum(unlist(sub_times))+self$runtime_self[[3]]
       }
       
       return(private$.runtime_total)

--- a/R/Delayed.R
+++ b/R/Delayed.R
@@ -199,7 +199,7 @@ Delayed <- R6Class(
       if(is.null(private$.runtime_total)){
         sub_times <- sapply(self$delayed_dependencies,`[[`,"runtime")
         
-        private$.runtime_total <- sum(unlist(sub_times))+self$runtime_self[[3]]
+        private$.runtime_total <- sum(unlist(sub_times))+self$runtime_self
       }
       
       return(private$.runtime_total)

--- a/R/Delayed.R
+++ b/R/Delayed.R
@@ -136,6 +136,7 @@ Delayed <- R6Class(
       value <- scheduler$compute()
       return(value)
     }
+    
   ),
 
   active = list(
@@ -191,8 +192,17 @@ Delayed <- R6Class(
 
       return(result)
     },
-    runtime = function() {
+    runtime_self = function() {
       return(private$.job$runtime)
+    },
+    runtime = function(){
+      if(is.null(private$.runtime_total)){
+        sub_times <- sapply(self$delayed_dependencies,`[[`,"runtime")
+        
+        private$.runtime_total <- sum(unlist(sub_times))+self$runtime_self
+      }
+      
+      return(private$.runtime_total)
     },
     state = function() {
       return(private$.state)
@@ -268,6 +278,7 @@ Delayed <- R6Class(
     .state = "waiting",
     .dependents = c(),
     .timeout = NULL,
+    .runtime_total = NULL,
     .seed = NULL
   )
 )

--- a/R/Job.R
+++ b/R/Job.R
@@ -169,7 +169,7 @@ FutureJob <- R6Class(
     finished = function() {
       finished <- resolved(private$.future)
       if (finished) {
-        private$.runtime <- (proc.time() - private$.start_time)
+        private$.runtime <- (proc.time() - private$.start_time)[[3]]
       }
       return(finished)
     },

--- a/R/Job.R
+++ b/R/Job.R
@@ -92,12 +92,14 @@ SequentialJob <- R6Class(
   public = list(
     initialize = function(delayed_object) {
       to_eval <- delayed_object$prepare_eval()
-      private$.runtime <- system.time({
-        private$.result <- try({
-          set.seed(delayed_object$seed)
-          eval_delayed(to_eval, delayed_object$timeout)
-        })
+      start_time <-proc.time()
+
+      private$.result <- try({
+        set.seed(delayed_object$seed)
+        eval_delayed(to_eval, delayed_object$timeout)
       })
+
+      private$.runtime <- (proc.time()-start_time)[[3]]
       super$initialize(delayed_object)
     }
   ),

--- a/R/Job.R
+++ b/R/Job.R
@@ -169,7 +169,7 @@ FutureJob <- R6Class(
     finished = function() {
       finished <- resolved(private$.future)
       if (finished) {
-        private$.runtime <- proc.time() - private$.start_time
+        private$.runtime <- (proc.time() - private$.start_time)
       }
       return(finished)
     },

--- a/tests/testthat/test_benchmark.R
+++ b/tests/testthat/test_benchmark.R
@@ -20,6 +20,8 @@ time_sequential <- system.time({
   result_sequential <- big_adder$compute(SequentialJob)
 })
 
+# test runtime logging
+expect_equivalent(time_sequential[[3]],big_adder$runtime, tol=0.1)
 nworkers <- 2
 
 big_adder <- make_adder_list()


### PR DESCRIPTION
Small changes to previous timing modification:

- use `proc.time` instead of `system.time` to clean up code and avoid garbage collection
- runtime now includes runtime of all dependent tasks (i.e. a `sl3` stack's runtime would be the total time, not the overhead for combining the stack)